### PR TITLE
Cvent Enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Gradle
 .gradle
 build
+target
 
 # IntelliJ
 .idea

--- a/README.md
+++ b/README.md
@@ -162,6 +162,39 @@ println mapper.writeValueAsString(hondaCivic)
 // prints '{"make": "honda", "model": "civic", "year": 2016, "new": "true", "modelVersion": "2"}'
 ```
 
+**Allow outbound serializeVersionTo to automatically match the inbound deserialized modelVersion
+```groovy
+@JsonVersionedModel(currentVersion = '3',
+                    toCurrentConverterClass = ToCurrentCarConverter,
+                    toPastConverterClass = ToPastCarConverter,
+                    defaultSerializeToVersionMatchModelVersion = true)
+class Car {
+    String make
+    String model
+    int year
+    boolean used
+
+    @JsonSerializeToVersion
+    String serializeToVersion
+}
+```
+
+Then your code for using this can change to this if you want the modelVersion to match:
+```groovy
+def mapper = new ObjectMapper().registerModule(new VersioningModule())
+
+// version 1 JSON -> POJO
+def hondaCivic = mapper.readValue(
+    '{"model": "honda:civic", "year": 2016, "new": "true", "modelVersion": "1"}',
+    Car
+)
+
+// POJO -> version 1 JSON
+println mapper.writeValueAsString(hondaCivic)
+// prints '{"model": "honda:civic", "year": 2016, "new": "true", "modelVersion": "1"}'
+```
+
+
 ### More Examples
 See the tests under `src/test/groovy` for more.
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.sonatype.oss</groupId>
+        <artifactId>oss-parent</artifactId>
+        <version>9</version>
+        <relativePath/>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.github.jonpeterson</groupId>
+    <artifactId>jackson-module-model-versioning</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>jackson-module-model-versioning</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.3.3</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/main/java/com/github/jonpeterson/jackson/module/versioning/JsonVersionedModel.java
+++ b/src/main/java/com/github/jonpeterson/jackson/module/versioning/JsonVersionedModel.java
@@ -45,24 +45,25 @@ public @interface JsonVersionedModel {
 
     /**
      * @return the version to convert the model to during serialization; this can be overridden by using
-     *         {@link JsonSerializeToVersion}
+     * {@link JsonSerializeToVersion}
      */
     String defaultSerializeToVersion() default "";
 
     /**
-     * @return class of the converter to use when resolving versioning to the current version.
+     * @return class of the converter to use when resolving versioning to the current version; not specifying will cause
+     * models to not be converted at all.
      */
-    Class<? extends VersionedModelConverter> toCurrentConverterClass();
+    Class<? extends VersionedModelConverter> toCurrentConverterClass() default VersionedModelConverter.class;
 
     /**
      * @return class of the converter to use when resolving versioning to a past version; not specifying will cause
-     *         models to be serialized as the current version
+     * models to be serialized as the current version
      */
     Class<? extends VersionedModelConverter> toPastConverterClass() default VersionedModelConverter.class;
 
     /**
      * @return whether to always send model data to converters, even when the data is the same version as the version to
-     *         convert to.
+     * convert to.
      */
     boolean alwaysConvert() default false;
 
@@ -70,4 +71,11 @@ public @interface JsonVersionedModel {
      * @return name of property in which the model's version is stored in JSON.
      */
     String propertyName() default "modelVersion";
+
+    /**
+     * Indicates if the default serializeToVersion should match the modelVersion of what was deserialized.  This is
+     * handy when dealing with services that want to respond with the same version that was requested for a service.
+     * @return Returns true if you want the serializeToVersion to match in deserialized modelVersion, false otherwise.
+     */
+    boolean defaultSerializeToVersionMatchModelVersion() default false;
 }

--- a/src/main/java/com/github/jonpeterson/jackson/module/versioning/VersioningBeanDeserializationModifier.java
+++ b/src/main/java/com/github/jonpeterson/jackson/module/versioning/VersioningBeanDeserializationModifier.java
@@ -28,12 +28,15 @@ import com.fasterxml.jackson.databind.DeserializationConfig;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.deser.BeanDeserializerModifier;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
+import static com.github.jonpeterson.jackson.module.versioning.VersioningBeanSerializationModifier.getSerializeToVersionProperty;
 
 class VersioningBeanDeserializationModifier extends BeanDeserializerModifier {
 
     // here just to make generics work without warnings
-    private static <T> VersionedModelDeserializer<T> createVersioningDeserializer(StdDeserializer<T> deserializer, JsonVersionedModel jsonVersionedModel) {
-        return new VersionedModelDeserializer<T>(deserializer, jsonVersionedModel);
+    private static <T> VersionedModelDeserializer<T> createVersioningDeserializer(StdDeserializer<T> deserializer, JsonVersionedModel jsonVersionedModel, 
+            BeanPropertyDefinition serializeToVersionProperty) {
+        return new VersionedModelDeserializer<T>(deserializer, jsonVersionedModel, serializeToVersionProperty);
     }
 
 
@@ -42,7 +45,8 @@ class VersioningBeanDeserializationModifier extends BeanDeserializerModifier {
         if(deserializer instanceof StdDeserializer) {
             JsonVersionedModel jsonVersionedModel = beanDescription.getClassAnnotations().get(JsonVersionedModel.class);
             if(jsonVersionedModel != null)
-                return createVersioningDeserializer((StdDeserializer)deserializer, jsonVersionedModel);
+                return createVersioningDeserializer((StdDeserializer)deserializer, jsonVersionedModel,
+                        getSerializeToVersionProperty(beanDescription));
         }
 
         return deserializer;

--- a/src/main/java/com/github/jonpeterson/jackson/module/versioning/VersioningBeanSerializationModifier.java
+++ b/src/main/java/com/github/jonpeterson/jackson/module/versioning/VersioningBeanSerializationModifier.java
@@ -38,7 +38,7 @@ class VersioningBeanSerializationModifier extends BeanSerializerModifier {
         return new VersionedModelSerializer<T>(serializer, jsonVersionedModel, serializeToVersionProperty);
     }
 
-    private static BeanPropertyDefinition getSerializeToVersionProperty(BeanDescription beanDescription) throws RuntimeException {
+    static BeanPropertyDefinition getSerializeToVersionProperty(BeanDescription beanDescription) throws RuntimeException {
         BeanPropertyDefinition serializeToVersionProperty = null;
         for(BeanPropertyDefinition definition: beanDescription.findProperties()) {
             AnnotatedMember accessor = definition.getAccessor();


### PR DESCRIPTION
- Adds the ability to have the serializeToVersion match the modelVersion from deserialized objects
- Adds the ability to not specify a ToCurrentConverter which in some cases we don't want because we're at version 1 of a model.
- Adds a maven pom.xml file so it works with maven ecosystems better
