### PR TITLE
allowMissingProperty for old models that weren't setup with versionin…

### DIFF
--- a/src/main/java/com/github/jonpeterson/jackson/module/versioning/JsonVersionedModel.java
+++ b/src/main/java/com/github/jonpeterson/jackson/module/versioning/JsonVersionedModel.java
@@ -71,4 +71,9 @@ public @interface JsonVersionedModel {
      * @return name of property in which the model's version is stored in JSON
      */
     String propertyName() default "modelVersion";
+
+    /**
+     * @return true for allowing non-existent propertyName() for inbound JSON, false otherwise
+     */
+    public boolean allowMissingProperty() default false;
 }

--- a/src/main/java/com/github/jonpeterson/jackson/module/versioning/VersionedModelDeserializer.java
+++ b/src/main/java/com/github/jonpeterson/jackson/module/versioning/VersionedModelDeserializer.java
@@ -77,20 +77,36 @@ class VersionedModelDeserializer<T> extends StdDeserializer<T> implements Resolv
         ObjectNode modelData = (ObjectNode)jsonNode;
 
         JsonNode modelVersionNode = modelData.remove(jsonVersionedModel.propertyName());
-        if(modelVersionNode == null)
-            throw context.mappingException("'" + jsonVersionedModel.propertyName() + "' property was not present");
-
-        String modelVersion = modelVersionNode.asText();
-        if(modelVersion == null)
-            throw context.mappingException("'" + jsonVersionedModel.propertyName() + "' property was null");
-
-        // convert the model if converter specified and model needs converting
-        if(converter != null && (jsonVersionedModel.alwaysConvert() || !modelVersion.equals(jsonVersionedModel.currentVersion())))
-            modelData = converter.convert(modelData, modelVersion, jsonVersionedModel.currentVersion(), context.getNodeFactory());
-
-        // set the serializeToVersionProperty value to the source model version if the defaultToSource property is true
-        if(serializeToVersionAnnotation != null && serializeToVersionAnnotation.defaultToSource())
-            modelData.put(serializeToVersionProperty.getName(), modelVersion);
+        String modelVersion = null;
+        if(modelVersionNode != null || !jsonVersionedModel.allowMissingProperty()) {
+            if (modelVersionNode == null && !jsonVersionedModel.allowMissingProperty()) {
+                throw context.mappingException("'" + jsonVersionedModel.propertyName() + "' property was not present");
+            }
+            
+            modelVersion = modelVersionNode.asText();
+            
+            if (modelVersion == null) {
+                throw context.mappingException("'" + jsonVersionedModel.propertyName() + "' property was null");
+            }
+            
+            // convert the model if converter specified and model needs converting
+            if (converter != null && (jsonVersionedModel.alwaysConvert() || !modelVersion.equals(jsonVersionedModel.
+                    currentVersion()))) {
+                modelData = converter.convert(modelData, modelVersion, jsonVersionedModel.currentVersion(), context.
+                        getNodeFactory());
+            }
+            
+            // set the serializeToVersionProperty value to the source model version if the defaultToSource property is true
+            if (serializeToVersionAnnotation != null && serializeToVersionAnnotation.defaultToSource()) {
+                modelData.put(serializeToVersionProperty.getName(), modelVersion);
+            }
+        } else {
+            // convert the model if converter specified and model needs converting
+            if (converter != null) {
+                modelData = converter.convert(modelData, modelVersion, jsonVersionedModel.currentVersion(), context.
+                        getNodeFactory());
+            }            
+        }
 
         JsonParser postInterceptionParser = new TreeTraversingParser(modelData, parser.getCodec());
         postInterceptionParser.nextToken();


### PR DESCRIPTION
Not sure if you have a cleaner way of doing this, but this seems to work ok.  Basically we need a way to support non-existent modelVersion data for deserialization because we often are dealing with models who were not setup with versioning from day 1 which essentially means we can treat them like version 0 in most cases.  This gives us that flexibility so we can deal with modelVersion being null in the converters.
