### PR TITLE
Add back missing functionality needed for cvent

### DIFF
--- a/src/main/java/com/github/jonpeterson/jackson/module/versioning/VersionedModelUtils.java
+++ b/src/main/java/com/github/jonpeterson/jackson/module/versioning/VersionedModelUtils.java
@@ -24,6 +24,7 @@
 package com.github.jonpeterson.jackson.module.versioning;
 
 import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.introspect.AnnotatedField;
 import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
 import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
 
@@ -33,7 +34,10 @@ public class VersionedModelUtils {
         BeanPropertyDefinition serializeToVersionProperty = null;
         for(BeanPropertyDefinition definition: beanDescription.findProperties()) {
             AnnotatedMember accessor = definition.getAccessor();
-            if(accessor != null && accessor.hasAnnotation(JsonSerializeToVersion.class)) {
+            AnnotatedField field = definition.getField();
+            
+            if ((accessor != null && accessor.hasAnnotation(JsonSerializeToVersion.class)) 
+                    || (field != null && field.hasAnnotation(JsonSerializeToVersion.class))) {
                 if(serializeToVersionProperty != null)
                     throw new RuntimeException("@" + JsonSerializeToVersion.class.getSimpleName() + " must be present on at most one field or method");
                 if(accessor.getRawType() != String.class || (definition.getField() == null && !definition.hasGetter()))


### PR DESCRIPTION
These are the changes/fixes we need to support our use cases at Cvent.  Some of the tests/code used to validate this are discussed here https://github.com/jonpeterson/jackson-module-model-versioning/pull/4

There are really a few scenarios I'd like out of this (I'm open to other options):
1.  I should be able to do this and it work properly:

```
    @JsonSerializeToVersion(defaultToSource = true)
    private String serializeToVersion;
```
1.  I should be able to deserialize JSON with 0 no modelVersion in it and serialize back out to JSON with no modelVersion defined
2.  I should be able to deserialize JSON with modelVersion of 1 while my concrete class is on version 3 and when I use @JsonSerializeToVersion(defaultToSource = true) it should serialize back out to modelVersion of 1 (not 3)

These changes fix all 3 cases above.  Hopefully this is helpful.
